### PR TITLE
Add support for genesis RPC calls

### DIFF
--- a/blockchain.go
+++ b/blockchain.go
@@ -27,6 +27,7 @@ type BlockChainClient interface {
 	ChainTips(ctx context.Context) ([]*models.ChainTip, error)
 	ChainTxStats(ctx context.Context, opts *models.OptsChainTxStats) (*models.ChainTxStats, error)
 	Difficulty(ctx context.Context) (float64, error)
+	InvalidateBlock(ctx context.Context, blockHash string) error
 	MerkleProof(ctx context.Context, blockHash, txID string, opts *models.OptsMerkleProof) (*bc.MerkleProof, error)
 	LegacyMerkleProof(ctx context.Context, txID string,
 		opts *models.OptsLegacyMerkleProof) (*models.LegacyMerkleProof, error)
@@ -137,6 +138,10 @@ func (c *client) ChainTxStats(ctx context.Context, opts *models.OptsChainTxStats
 func (c *client) Difficulty(ctx context.Context) (float64, error) {
 	var resp float64
 	return resp, c.rpc.Do(ctx, "getdifficulty", &resp)
+}
+
+func (c *client) InvalidateBlock(ctx context.Context, blockHash string) error {
+	return c.rpc.Do(ctx, "invalidateblock", nil, blockHash)
 }
 
 func (c *client) MempoolEntry(ctx context.Context, txID string) (*models.MempoolEntry, error) {

--- a/examples/add_to_confiscation_tx_whitelist/main.go
+++ b/examples/add_to_confiscation_tx_whitelist/main.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/libsv/go-bn/models"
+
+	"github.com/libsv/go-bn"
+)
+
+func main() {
+	c := bn.NewNodeClient(
+		bn.WithHost("http://localhost:8333"),
+		bn.WithCreds("galt", "galt"),
+	)
+	ctx := context.Background()
+
+	funds := []models.Fund{
+		{
+			TxOut: models.TxOut{
+				TxId: "",
+				Vout: 0,
+			},
+			EnforceAtHeight: []models.Enforce{
+				{
+					Start: 100000,
+					Stop:  100001,
+				},
+			},
+			PolicyExpiresWithConsensus: false,
+		},
+	}
+
+	resp, err := c.AddToConsensusBlacklist(ctx, funds)
+	if err != nil {
+		panic(err)
+	}
+
+	bb, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(bb))
+}

--- a/examples/add_to_consensus_blacklist/main.go
+++ b/examples/add_to_consensus_blacklist/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/libsv/go-bn/models"
+
+	"github.com/libsv/go-bn"
+)
+
+func main() {
+	c := bn.NewNodeClient(
+		bn.WithHost("http://localhost:8333"),
+		bn.WithCreds("galt", "galt"),
+	)
+	ctx := context.Background()
+
+	txs := []models.ConfiscationTransactionDetails{
+		{
+			ConfiscationTransaction: models.ConfiscationTransaction{
+				EnforceAtHeight: 10000,
+				Hex:             "",
+			},
+		},
+	}
+
+	resp, err := c.AddToConfiscationTransactionWhitelist(ctx, txs)
+	if err != nil {
+		panic(err)
+	}
+
+	bb, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(string(bb))
+}

--- a/mocks/node_client.go
+++ b/mocks/node_client.go
@@ -542,6 +542,9 @@ type NodeClientMock struct {
 	// InfoFunc mocks the Info method.
 	InfoFunc func(ctx context.Context) (*models.Info, error)
 
+	// InvalidateBlockFunc mocks the InvalidateBlock method.
+	InvalidateBlockFunc func(ctx context.Context, hash string) error
+
 	// KeypoolRefillFunc mocks the KeypoolRefill method.
 	KeypoolRefillFunc func(ctx context.Context, opts *models.OptsKeypoolRefill) error
 
@@ -1106,6 +1109,13 @@ type NodeClientMock struct {
 		Info []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
+		}
+		// InvalidateBlock holds details about calls to the InvalidateBlock method.
+		InvalidateBlock []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// BlockHash is the hash argument value.
+			BlockHash string
 		}
 		// KeypoolRefill holds details about calls to the KeypoolRefill method.
 		KeypoolRefill []struct {
@@ -1677,6 +1687,7 @@ type NodeClientMock struct {
 	lockImportPublicKey           sync.RWMutex
 	lockImportWallet              sync.RWMutex
 	lockInfo                      sync.RWMutex
+	lockInvalidateBlock                     sync.RWMutex
 	lockKeypoolRefill             sync.RWMutex
 	lockLegacyMerkleProof         sync.RWMutex
 	lockListAccounts              sync.RWMutex
@@ -3472,6 +3483,24 @@ func (mock *NodeClientMock) InfoCalls() []struct {
 	calls = mock.calls.Info
 	mock.lockInfo.RUnlock()
 	return calls
+}
+
+// InvalidateBlock calls InvalidateBlockFunc.
+func (mock *NodeClientMock) InvalidateBlock(ctx context.Context, hash string) error {
+	if mock.InvalidateBlockFunc == nil {
+		panic("NodeClientMock.InvalidateBlockFunc: method is nil but NodeClient.InvalidateBlock was just called")
+	}
+	callInfo := struct {
+		Ctx  context.Context
+		BlockHash string
+	}{
+		Ctx:  ctx,
+		BlockHash: hash,
+	}
+	mock.lockBlock.Lock()
+	mock.calls.InvalidateBlock = append(mock.calls.InvalidateBlock, callInfo)
+	mock.lockBlock.Unlock()
+	return mock.InvalidateBlockFunc(ctx, hash)
 }
 
 // KeypoolRefill calls KeypoolRefillFunc.

--- a/mocks/node_client.go
+++ b/mocks/node_client.go
@@ -416,6 +416,12 @@ type NodeClientMock struct {
 	// AddNodeFunc mocks the AddNode method.
 	AddNodeFunc func(ctx context.Context, node string, command internal.NodeAddType) error
 
+	// AddToConfiscationTransactionWhitelist mocks the AddToConfiscationTransactionWhitelist method
+	AddToConfiscationTransactionWhitelistFunc func(ctx context.Context, confiscationTransactions []models.ConfiscationTransactionDetails) (*models.AddToConfiscationTransactionWhitelistResponse, error)
+
+	// AddToConsensusBlacklistFunc mocks the AddToConsensusBlacklist
+	AddToConsensusBlacklistFunc func(ctx context.Context, funds []models.Fund) (*models.AddToConsensusBlacklistResponse, error)
+
 	// BackupWalletFunc mocks the BackupWallet method.
 	BackupWalletFunc func(ctx context.Context, dest string) error
 
@@ -813,6 +819,20 @@ type NodeClientMock struct {
 			Node string
 			// Command is the command argument value.
 			Command internal.NodeAddType
+		}
+		// AddToConfiscationTransactionWhitelist holds details about calls to the AddToConfiscationTransactionWhitelist method
+		AddToConfiscationTransactionWhitelist []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ConfiscationTransactions is the confiscation transactions argument value
+			ConfiscationTransactions []models.ConfiscationTransactionDetails
+		}
+		// AddToConsensusBlacklist holds details about calls to the AddToConsensusBlacklist method
+		AddToConsensusBlacklist []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Funds is the funds argument value
+			Funds []models.Fund
 		}
 		// BackupWallet holds details about calls to the BackupWallet method.
 		BackupWallet []struct {
@@ -1645,6 +1665,8 @@ type NodeClientMock struct {
 	lockActiveZMQNotifications    sync.RWMutex
 	lockAddMultiSigAddress        sync.RWMutex
 	lockAddNode                   sync.RWMutex
+	lockAddToConsensusBlacklist                   sync.RWMutex
+	lockAddToConfiscationTransactionWhitelist sync.RWMutex
 	lockBackupWallet              sync.RWMutex
 	lockBalance                   sync.RWMutex
 	lockBestBlockHash             sync.RWMutex
@@ -2009,6 +2031,42 @@ func (mock *NodeClientMock) AddNodeCalls() []struct {
 	calls = mock.calls.AddNode
 	mock.lockAddNode.RUnlock()
 	return calls
+}
+
+// AddToConfiscationTransactionWhitelist calls AddToConfiscationTransactionWhitelistFunc
+func (mock *NodeClientMock) AddToConfiscationTransactionWhitelist(ctx context.Context, confiscationTxs []models.ConfiscationTransactionDetails) (*models.AddToConfiscationTransactionWhitelistResponse, error) {
+	if mock.AddToConfiscationTransactionWhitelistFunc == nil {
+		panic("TransactionClientMock.AddToConfiscationTransactionWhitelistFunc: method is nil but TransactionClient.AddToConfiscationTransactionWhitelist was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		ConfiscationTransactions []models.ConfiscationTransactionDetails
+	}{
+		Ctx: ctx,
+		ConfiscationTransactions: confiscationTxs,
+	}
+	mock.lockAddToConfiscationTransactionWhitelist.Lock()
+	mock.calls.AddToConfiscationTransactionWhitelist = append(mock.calls.AddToConfiscationTransactionWhitelist, callInfo)
+	mock.lockAddToConfiscationTransactionWhitelist.Unlock()
+	return mock.AddToConfiscationTransactionWhitelist(ctx, confiscationTxs)
+}
+
+// AddToConsensusBlacklist calls AddToConsensusBlacklistFunc
+func (mock *NodeClientMock) AddToConsensusBlacklist(ctx context.Context, funds []models.Fund) (*models.AddToConsensusBlacklistResponse, error) {
+	if mock.AddToConsensusBlacklistFunc == nil {
+		panic("TransactionClientMock.AddToConsensusBlacklistFunc: method is nil but TransactionClient.CreateRawTransaction was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Funds []models.Fund
+	}{
+		Ctx: ctx,
+		Funds: funds,
+	}
+	mock.lockAddToConsensusBlacklist.Lock()
+	mock.calls.AddToConsensusBlacklist = append(mock.calls.AddToConsensusBlacklist, callInfo)
+	mock.lockAddToConsensusBlacklist.Unlock()
+	return mock.AddToConsensusBlacklistFunc(ctx, funds)
 }
 
 // BackupWallet calls BackupWalletFunc.

--- a/mocks/transaction_client.go
+++ b/mocks/transaction_client.go
@@ -46,6 +46,12 @@ var _ bn.TransactionClient = &TransactionClientMock{}
 //
 // 	}
 type TransactionClientMock struct {
+	// AddToConfiscationTransactionWhitelist mocks the AddToConfiscationTransactionWhitelist method
+	AddToConfiscationTransactionWhitelistFunc func(ctx context.Context, confiscationTransactions []models.ConfiscationTransactionDetails) (*models.AddToConfiscationTransactionWhitelistResponse, error)
+
+	// AddToConsensusBlacklistFunc mocks the AddToConsensusBlacklist method
+	AddToConsensusBlacklistFunc func(ctx context.Context, funds []models.Fund) (*models.AddToConsensusBlacklistResponse, error)
+
 	// CreateRawTransactionFunc mocks the CreateRawTransaction method.
 	CreateRawTransactionFunc func(ctx context.Context, utxos bt.UTXOs, params models.ParamsCreateRawTransaction) (*bt.Tx, error)
 
@@ -66,6 +72,20 @@ type TransactionClientMock struct {
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// AddToConsensusBlacklist holds details about calls to the AddToConsensusBlacklist method
+		AddToConsensusBlacklist []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Funds is the funds argument value
+			Funds []models.Fund
+		}
+		// AddToConfiscationTransactionWhitelist holds details about calls to the AddToConfiscationTransactionWhitelist method
+		AddToConfiscationTransactionWhitelist []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// ConfiscationTransactions is the confiscation transactions argument value
+			ConfiscationTransactions []models.ConfiscationTransactionDetails
+		}
 		// CreateRawTransaction holds details about calls to the CreateRawTransaction method.
 		CreateRawTransaction []struct {
 			// Ctx is the ctx argument value.
@@ -117,12 +137,50 @@ type TransactionClientMock struct {
 			Opts *models.OptsSignRawTransaction
 		}
 	}
+	lockAddToConsensusBlacklist sync.RWMutex
+	lockAddToConfiscationTransactionWhitelist sync.RWMutex
 	lockCreateRawTransaction sync.RWMutex
 	lockFundRawTransaction   sync.RWMutex
 	lockRawTransaction       sync.RWMutex
 	lockSendRawTransaction   sync.RWMutex
 	lockSendRawTransactions  sync.RWMutex
 	lockSignRawTransaction   sync.RWMutex
+}
+
+// AddToConsensusBlacklist calls AddToConsensusBlacklistFunc
+func (mock *TransactionClientMock) AddToConsensusBlacklist(ctx context.Context, funds []models.Fund) (*models.AddToConsensusBlacklistResponse, error) {
+	if mock.AddToConsensusBlacklistFunc == nil {
+		panic("TransactionClientMock.AddToConsensusBlacklistFunc: method is nil but TransactionClient.AddToConsensusBlacklist was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		Funds []models.Fund
+	}{
+		Ctx: ctx,
+		Funds: funds,
+	}
+	mock.lockAddToConsensusBlacklist.Lock()
+	mock.calls.AddToConsensusBlacklist = append(mock.calls.AddToConsensusBlacklist, callInfo)
+	mock.lockAddToConsensusBlacklist.Unlock()
+	return mock.AddToConsensusBlacklistFunc(ctx, funds)
+}
+
+// AddToConfiscationTransactionWhitelist calls AddToConfiscationTransactionWhitelistFunc
+func (mock *TransactionClientMock) AddToConfiscationTransactionWhitelist(ctx context.Context, confiscationTxs []models.ConfiscationTransactionDetails) (*models.AddToConfiscationTransactionWhitelistResponse, error) {
+	if mock.AddToConfiscationTransactionWhitelistFunc == nil {
+		panic("TransactionClientMock.AddToConfiscationTransactionWhitelistFunc: method is nil but TransactionClient.AddToConfiscationTransactionWhitelist was just called")
+	}
+	callInfo := struct {
+		Ctx   context.Context
+		ConfiscationTransactions []models.ConfiscationTransactionDetails
+	}{
+		Ctx: ctx,
+		ConfiscationTransactions: confiscationTxs,
+	}
+	mock.lockAddToConfiscationTransactionWhitelist.Lock()
+	mock.calls.AddToConfiscationTransactionWhitelist = append(mock.calls.AddToConfiscationTransactionWhitelist, callInfo)
+	mock.lockAddToConfiscationTransactionWhitelist.Unlock()
+	return mock.AddToConfiscationTransactionWhitelist(ctx, confiscationTxs)
 }
 
 // CreateRawTransaction calls CreateRawTransactionFunc.

--- a/models/tx.go
+++ b/models/tx.go
@@ -18,6 +18,42 @@ type Output struct {
 	*bt.Output
 }
 
+type AddToConsensusBlacklistArgs struct {
+	Funds []Fund `json:"funds"`
+}
+
+type AddToConfiscationTxIdWhitelistArgs struct {
+	ConfiscationTransactions []ConfiscationTransactionDetails `json:"confiscationTxs"`
+}
+
+type ConfiscationTransactionDetails struct {
+	ConfiscationTransaction ConfiscationTransaction `json:"confiscationTx"`
+}
+
+type ConfiscationTransaction struct {
+	EnforceAtHeight int64  `json:"enforceAtHeight"`
+	Hex             string `json:"hex"`
+}
+
+// Fund represents a fund to freeze or unfreeze
+type Fund struct {
+	TxOut                      TxOut     `json:"txOut"`
+	EnforceAtHeight            []Enforce `json:"enforceAtHeight"`
+	PolicyExpiresWithConsensus bool      `json:"policyExpiresWithConsensus"`
+}
+
+// Enforce represents block start and end to enforce freezing
+type Enforce struct {
+	Start int `json:"start"`
+	Stop  int `json:"stop"`
+}
+
+// Txout represents transaction output
+type TxOut struct {
+	TxId string `json:"txId""`
+	Vout int    `json:"vout"`
+}
+
 // NodeJSON return node json variant.
 func (o *Output) NodeJSON() interface{} {
 	return o
@@ -211,4 +247,24 @@ type SendRawTransactionsResponse struct {
 			} `json:"vin"`
 		} `json:"ancestors"`
 	} `json:"unconfirmed"`
+}
+
+// AddToConsensusBlacklistResponse response
+type AddToConsensusBlacklistResponse struct {
+	NotProcessed []struct {
+		TxOut struct {
+			TxId string `json:"txId"`
+			Vout int    `json:"vout"`
+		} `json:"txOut"`
+		Reason string `json:"reason"`
+	} `json:"notProcessed"`
+}
+
+type AddToConfiscationTransactionWhitelistResponse struct {
+	NotProcessed []struct {
+		ConfiscationTransaction struct {
+			TxId string `json:"txId"`
+		} `json:"confiscationTx"`
+		Reason string `json:"reason"`
+	} `json:"notProcessed"`
 }

--- a/models/tx.go
+++ b/models/tx.go
@@ -50,7 +50,7 @@ type Enforce struct {
 
 // Txout represents transaction output
 type TxOut struct {
-	TxId string `json:"txId""`
+	TxId string `json:"txId"`
 	Vout int    `json:"vout"`
 }
 

--- a/tx.go
+++ b/tx.go
@@ -2,7 +2,6 @@ package bn
 
 import (
 	"context"
-
 	imodels "github.com/libsv/go-bn/internal/models"
 	"github.com/libsv/go-bn/models"
 	"github.com/libsv/go-bt/v2"
@@ -10,6 +9,8 @@ import (
 
 // TransactionClient interfaces interaction with the transaction sub commands on a bitcoin node.
 type TransactionClient interface {
+	AddToConfiscationTransactionWhitelist(ctx context.Context, funds []models.ConfiscationTransactionDetails) (*models.AddToConfiscationTransactionWhitelistResponse, error)
+	AddToConsensusBlacklist(ctx context.Context, funds []models.Fund) (*models.AddToConsensusBlacklistResponse, error)
 	CreateRawTransaction(ctx context.Context, utxos bt.UTXOs, params models.ParamsCreateRawTransaction) (*bt.Tx, error)
 	FundRawTransaction(ctx context.Context, tx *bt.Tx,
 		opts *models.OptsFundRawTransaction) (*models.FundRawTransaction, error)
@@ -64,4 +65,18 @@ func (c *client) SendRawTransactions(ctx context.Context,
 	params ...models.ParamsSendRawTransactions) (*models.SendRawTransactionsResponse, error) {
 	var resp models.SendRawTransactionsResponse
 	return &resp, c.rpc.Do(ctx, "sendrawtransactions", &resp, params)
+}
+
+func (c *client) AddToConsensusBlacklist(ctx context.Context, funds []models.Fund) (*models.AddToConsensusBlacklistResponse, error) {
+	var resp models.AddToConsensusBlacklistResponse
+	req := models.AddToConsensusBlacklistArgs{Funds: funds}
+	return &resp, c.rpc.Do(ctx, "addToConsensusBlacklist", &resp, req)
+}
+
+func (c *client) AddToConfiscationTransactionWhitelist(ctx context.Context, confiscationTransactions []models.ConfiscationTransactionDetails) (*models.AddToConfiscationTransactionWhitelistResponse, error) {
+	var resp models.AddToConfiscationTransactionWhitelistResponse
+	req := models.AddToConfiscationTxIdWhitelistArgs{
+		confiscationTransactions,
+	}
+	return &resp, c.rpc.Do(ctx, "addToConfiscationTxidWhitelist", &resp, req)
 }


### PR DESCRIPTION
This pull request introduces new functionality for managing blockchain consensus rules and enhances the mocking framework for testing. Key changes include the addition of methods for handling confiscation transaction whitelists and consensus blacklists, updates to the `BlockChainClient` interface, and expanded mock implementations to support these new methods.

### New Functionality for Blockchain Consensus Management:
* Added `AddToConfiscationTransactionWhitelist` and `AddToConsensusBlacklist` methods to the `TransactionClient` interface in `tx.go`. These methods allow managing confiscation transactions and freezing/unfreezing funds.
* Introduced new data structures in `models/tx.go`, including `AddToConsensusBlacklistArgs`, `AddToConfiscationTxIdWhitelistArgs`, `Fund`, `Enforce`, and response types for the new methods. [[1]](diffhunk://#diff-6d5301c97541b896843d5363919d90686ed3489ab0ced2d2977848ff6daafb74R21-R56) [[2]](diffhunk://#diff-6d5301c97541b896843d5363919d90686ed3489ab0ced2d2977848ff6daafb74R251-R270)

### Updates to `BlockChainClient` Interface:
* Added the `InvalidateBlock` method to the `BlockChainClient` interface in `blockchain.go`, enabling invalidation of specific blocks. [[1]](diffhunk://#diff-1fb2891d150a66e1319495e4f10a7ce04855476836a3a6b17f253e312f37d23bR30) [[2]](diffhunk://#diff-1fb2891d150a66e1319495e4f10a7ce04855476836a3a6b17f253e312f37d23bR143-R146)

### Mocking Framework Enhancements:
* Updated `BlockChainClientMock` in `mocks/blockchain_client.go` to mock the `InvalidateBlock` method and track its calls. [[1]](diffhunk://#diff-c5ae121b5246003760b30600f0b29682224cc5118c145724a90f604f4fdd965fR199-R201) [[2]](diffhunk://#diff-c5ae121b5246003760b30600f0b29682224cc5118c145724a90f604f4fdd965fR390-R396) [[3]](diffhunk://#diff-c5ae121b5246003760b30600f0b29682224cc5118c145724a90f604f4fdd965fR1243-R1260)
* Enhanced `NodeClientMock` and `TransactionClientMock` in `mocks/node_client.go` and `mocks/transaction_client.go` to mock the `AddToConfiscationTransactionWhitelist` and `AddToConsensusBlacklist` methods, including call tracking. [[1]](diffhunk://#diff-331327a6c192ed93a2352ad6116d7018860369adb2b57a9bc624a329e17b646aR419-R424) [[2]](diffhunk://#diff-52e14cc2e5e7cca8b1be615d668e382c6f6d61ae397056a75ac421e01584d160R49-R54)

### Examples for New Features:
* Added example programs in `examples/add_to_confiscation_tx_whitelist/main.go` and `examples/add_to_consensus_blacklist/main.go` demonstrating how to use the new methods. [[1]](diffhunk://#diff-09f761f8cdeffd346b9e313df057cc7e7b69365e0e419170365af5e964e96805R1-R45) [[2]](diffhunk://#diff-dbe56eefdef940ed0e8af35ff5e54353581c98dda6c434967e7a5cc233031c0cR1-R38)